### PR TITLE
Made code Python 2 compatible. #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.egg-info
 __pycache__
+*.pyc

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
 	name     = 'textdistance',
-	version  = '1.0.0',
+	version  = '1.0.1',
 	
 	author       = 'orsinium',
 	author_email = 'master_fess@mail.ru',
@@ -16,7 +16,7 @@ setup(
 	keywords         = 'distance between text strings sequences iterators',
 	
 	packages = ['textdistance'],
-	requires = ['python (>= 3.4)'],
+	requires = ['python (>= 2.7)'],
 	
 	url          = 'https://github.com/orsinium/textdistance',
 	download_url = 'https://github.com/orsinium/textdistance/tarball/master',

--- a/tests.py
+++ b/tests.py
@@ -1,8 +1,16 @@
 import unittest
-from textdistance import distance
+from textdistance import distance, PY3
 
 
 class TestAlgos(unittest.TestCase):
+
+	def setUp(self):
+		if not PY3:
+			from contextlib import contextmanager
+			@contextmanager
+			def breakOnFirstError(*args, **kwargs):
+				yield
+			self.subTest = breakOnFirstError
 	
 	def test_hamming(self):
 		with self.subTest(length='equal', distance='1', texts='2'):

--- a/tests.py
+++ b/tests.py
@@ -52,6 +52,11 @@ class TestAlgos(unittest.TestCase):
 		with self.subTest(algo='h', distance='1'):
 			self.assertEqual(distance.find_minimal('h', 'lorem', ['larum', 'lorum']), (1, 'lorum'))
 
+	def test_maximal(self):
+		with self.subTest(algo='h', distance='200'):
+			self.assertEqual(distance('h', 'abcdeflko' * 100, 'bcafedlko' * 100), 500)
+			# self.assertEqual(distance('l', 'abcdeflko' * 100, 'bcafedlko' * 100), 500)  # crashes due to recursion depth
+
 
 if __name__ == '__main__':
 	unittest.main()

--- a/textdistance/__init__.py
+++ b/textdistance/__init__.py
@@ -1,4 +1,12 @@
-from itertools import zip_longest, product, permutations
+import sys
+
+PY3 = sys.version_info.major >= 3
+
+if PY3:
+	from itertools import zip_longest
+else:
+	from itertools import izip_longest as zip_longest
+
 
 class Distance:
 	'''
@@ -104,23 +112,7 @@ class Distance:
 				if i and j and s1[i] == s2[j - 1] and s1[i - 1] == s2[j]:
 					d[i, j] = min(d[i, j], d[i - 2, j - 2] + cost) #transposition
 		return d[len_s1 - 1, len_s2 - 1]
-	
-	@staticmethod
-	def w(f, *texts, equality=False):
-		m = float('Inf')
-		#split by words
-		texts = [t.split() for t in texts]
-		#permutations
-		texts = [permutations(words) for words in texts]
-		#combinations
-		for subtexts in product(*texts):
-			if equality:
-				words_min_cnt = len(min(subtexts, key=len))
-				subtexts = [t[:words_min_cnt] for t in subtexts]
-			subtexts = [' '.join(t) for t in subtexts]
-			m = min(m, f(*subtexts))
-		return m
-	
+
 	def __call__(self, algorithm, *texts):
 		if algorithm[0] == 'h':
 			f = self.h
@@ -136,13 +128,21 @@ class Distance:
 			raise KeyError('bad algorithm!')
 		
 		if algorithm[-2:] == 'we':
-			return self.w(f, *texts, equality=True)
+			return self.w(f, *texts, equality=True) if PY3 else self.w(f, True,  *texts)
 		if algorithm[-1] == 'w':
-			return self.w(f, *texts)
+			return self.w(f, *texts)                if PY3 else self.w(f, False, *texts)
 		return f(*texts)
 	
 	def find_minimal(self, algorithm, text, texts):
 		return min([(self(algorithm, text, t), t) for t in texts])
+
+
+# dynamic definition of static method due to differing syntax
+if PY3:
+	from textdistance.py3 import w as _w  # requires package prefix
+else:  # is PY2
+	from py2 import w as _w
+Distance.w = _w
 
 
 distance = Distance()

--- a/textdistance/internal.py
+++ b/textdistance/internal.py
@@ -1,0 +1,16 @@
+from itertools import product, permutations
+
+def w_intern(f, equality, *texts):
+	m = float('Inf')
+	#split by words
+	texts = [t.split() for t in texts]
+	#permutations
+	texts = [permutations(words) for words in texts]
+	#combinations
+	for subtexts in product(*texts):
+		if equality:
+			words_min_cnt = len(min(subtexts, key=len))
+			subtexts = [t[:words_min_cnt] for t in subtexts]
+		subtexts = [' '.join(t) for t in subtexts]
+		m = min(m, f(*subtexts))
+	return m

--- a/textdistance/py2.py
+++ b/textdistance/py2.py
@@ -1,0 +1,5 @@
+from internal import w_intern
+
+@staticmethod
+def w(f, equality=False, *texts):
+	return w_intern(f, equality, *texts)

--- a/textdistance/py3.py
+++ b/textdistance/py3.py
@@ -1,0 +1,5 @@
+from textdistance.internal import w_intern
+
+@staticmethod
+def w(f, *texts, equality=False):
+	return w_intern(f, equality, *texts)


### PR DESCRIPTION
This is not a "nice" change since I think you insisted on keeping the `*vararg` and keyword-args in the code.
So it required to pull out Python2- and Python3-specific code to different files with different imports and Python-dependent invocations (using keyword for Py3 and positional parameter for Py2).

I would simply have made the `equality` parameter positional and mandatory instead.
But it seems to run now on Py2 and Py3.

Probably we need to update the setup.py to allow for Python2 use as well and bump up the version number.